### PR TITLE
Use 0.2.x branch of grpc4bmi so additional functions are not needed

### DIFF
--- a/walrus/Dockerfile
+++ b/walrus/Dockerfile
@@ -2,7 +2,7 @@ FROM r-base
 LABEL maintainer="Stefan Verhoeven <s.verhoeven@esciencecenter.nl>"
 
 RUN apt update && apt install -t unstable -y python3-dev python3-pip git && \
-  pip3 install git+https://github.com/eWaterCycle/grpc4bmi.git#egg=grpc4bmi[R]
+  pip3 install git+https://github.com/eWaterCycle/grpc4bmi.git@0.2.x#egg=grpc4bmi[R]
 
 RUN install.r remotes && installGithub.r ClaudiaBrauer/WALRUS eWaterCycle/bmi-r
 


### PR DESCRIPTION
The Walrus code uses old BMI interface, in Dockerfile install compatible grpc4bmi

Fixes #16 